### PR TITLE
Add post about joining the Open Source Collective

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ params:
     disableThemeToggle: false
 
     ShowReadingTime: true
-    ShowShareButtons: true
+    ShowShareButtons: false
     ShowPostNavLinks: true
     ShowBreadCrumbs: true
     ShowCodeCopyButtons: true

--- a/content/posts/pyodide-joins-open-source-collective.md
+++ b/content/posts/pyodide-joins-open-source-collective.md
@@ -1,0 +1,47 @@
+---
+title: "Pyodide becomes member of the Open Source Collective"
+date: 2021-11-10T13:13:04+01:00
+draft: true
+tags: ["announcement"]
+author: "Roman Yurchak on behalf of the Pyodide team"
+showToc: false
+TocOpen: false
+draft: true
+hidemeta: false
+comments: false
+# description: "Desc Text."
+# canonicalURL: "https://canonical.url/to/page"
+disableHLJS: true # to disable highlightjs
+disableShare: false
+hideSummary: false
+searchHidden: true
+ShowReadingTime: true
+ShowBreadCrumbs: true
+ShowPostNavLinks: true
+#cover:
+#    image: "<image path/url>" # image path/url
+#    alt: "<alt text>" # alt text
+#    caption: "<text>" # display caption under cover
+#    relative: false # when using page bundles set this to true
+#    hidden: true # only hide on current single page
+---
+
+We would like to announce that Pyodide is now member of the [Open Source
+Collective (OSC)](https://www.oscollective.org/), which will act as project's
+fiscal host.
+
+The Pyodide project, that compiles Python and the scientific stack to
+WebAssembly, was created in 2018 by Michael
+Droettboom at Mozilla as part of the [Iodide
+project](https://github.com/iodide-project/iodide). Later in 2021 [Pyodide
+become an indepenent open-source
+project](https://hacks.mozilla.org/2021/04/pyodide-spin-out-and-0-17-release/),
+and the current annoucement completes this transition. By selecting OSC as our
+fiscal host, Pyodide will be able to recieve donnations and accepts
+sponsorships which would help long term project sustainability.
+
+We are now accepting donations at:
+ - the OSC project page: [opencollective.com/pyodide](https://opencollective.com/pyodide)
+ - or via Github Sponsors: [github.com/sponsors/pyodide](https://github.com/sponsors/pyodide)
+
+Funds will be mostly spent to organize in-person developer sprints.

--- a/content/posts/pyodide-joins-open-source-collective.md
+++ b/content/posts/pyodide-joins-open-source-collective.md
@@ -3,7 +3,7 @@ title: "Pyodide becomes member of the Open Source Collective"
 date: 2021-11-10T13:13:04+01:00
 draft: true
 tags: ["announcement"]
-author: "Roman Yurchak on behalf of the Pyodide team"
+author: "Roman Yurchak and Hood Chatham, on behalf of the Pyodide team"
 showToc: false
 TocOpen: false
 draft: true
@@ -36,11 +36,23 @@ Droettboom at Mozilla as part of the [Iodide
 project](https://github.com/iodide-project/iodide). Later in 2021 [Pyodide
 become an independent open-source
 project](https://hacks.mozilla.org/2021/04/pyodide-spin-out-and-0-17-release/),
-and the current announcement completes this transition. Pyodide will now be able to receive donations and accept
-sponsorships though OSC, which will help long term project sustainability.
+and the current announcement completes this transition.
 
-We are now accepting donations at:
- - the OSC project page: [opencollective.com/pyodide](https://opencollective.com/pyodide)
- - or via Github Sponsors: [github.com/sponsors/pyodide](https://github.com/sponsors/pyodide)
+Pyodide is now
+able to receive donations and accept sponsorships though Open Source Collective, which should help
+long term project sustainability. We have looked at a few non-profit umbrella
+organizations before making this choice, and we quite like the financial
+transparency and ease of setup offered by OSC. In addition, since Pyodide use
+cases are wider than scientific computing, we felt that a non specialized
+fiscal host would be best.
 
+We are now accepting donations at the OSC project page: [opencollective.com/pyodide](https://opencollective.com/pyodide) .
 Funds will be mostly spent to organize in-person developer sprints.
+
+On a different subject, Pyodide now has a blog, where you are reading this
+post. In the future we will share here project announcement, examples of real
+world use cases for Pyodide, as well as more technical posts about how Pyodide
+works. We also accept guest posts on
+[Github](https://github.com/pyodide/pyodide-blog).
+
+Stay tuned.

--- a/content/posts/pyodide-joins-open-source-collective.md
+++ b/content/posts/pyodide-joins-open-source-collective.md
@@ -30,15 +30,14 @@ We would like to announce that Pyodide is now member of the [Open Source
 Collective (OSC)](https://www.oscollective.org/), which will act as project's
 fiscal host.
 
-The Pyodide project, that compiles Python and the scientific stack to
-WebAssembly, was created in 2018 by Michael
+The Pyodide project compiles Python and the scientific stack to WebAssembly using Emscripten. 
+Pyodide was created in 2018 by Michael
 Droettboom at Mozilla as part of the [Iodide
 project](https://github.com/iodide-project/iodide). Later in 2021 [Pyodide
-become an indepenent open-source
+become an independent open-source
 project](https://hacks.mozilla.org/2021/04/pyodide-spin-out-and-0-17-release/),
-and the current annoucement completes this transition. By selecting OSC as our
-fiscal host, Pyodide will be able to recieve donnations and accepts
-sponsorships which would help long term project sustainability.
+and the current announcement completes this transition. Pyodide will now be able to receive donations and accept
+sponsorships though OSC, which will help long term project sustainability.
 
 We are now accepting donations at:
  - the OSC project page: [opencollective.com/pyodide](https://opencollective.com/pyodide)

--- a/content/posts/pyodide-joins-open-source-collective.md
+++ b/content/posts/pyodide-joins-open-source-collective.md
@@ -54,5 +54,3 @@ post. In the future we will share here project announcement, examples of real
 world use cases for Pyodide, as well as more technical posts about how Pyodide
 works. We also accept guest posts on
 [GitHub](https://github.com/pyodide/pyodide-blog).
-
-Stay tuned.

--- a/content/posts/pyodide-joins-open-source-collective.md
+++ b/content/posts/pyodide-joins-open-source-collective.md
@@ -21,7 +21,7 @@ ShowPostNavLinks: true
 #cover:
 #    image: "<image path/url>" # image path/url
 #    alt: "<alt text>" # alt text
-#    caption: "<text>" # display caption under cover
+#    caption: "<text>" # display caption under the cover
 #    relative: false # when using page bundles set this to true
 #    hidden: true # only hide on current single page
 ---
@@ -43,16 +43,16 @@ able to receive donations and accept sponsorships though Open Source Collective,
 long term project sustainability. We have looked at a few non-profit umbrella
 organizations before making this choice, and we quite like the financial
 transparency and ease of setup offered by OSC. In addition, since Pyodide use
-cases are wider than scientific computing, we felt that a non specialized
+cases are wider than scientific computing, we felt that a non-specialized
 fiscal host would be best.
 
-We are now accepting donations at the OSC project page: [opencollective.com/pyodide](https://opencollective.com/pyodide) .
+We are now accepting donations at the OSC project page: [opencollective.com/pyodide](https://opencollective.com/pyodide)
 Funds will be mostly spent to organize in-person developer sprints.
 
 On a different subject, Pyodide now has a blog, where you are reading this
 post. In the future we will share here project announcement, examples of real
 world use cases for Pyodide, as well as more technical posts about how Pyodide
 works. We also accept guest posts on
-[Github](https://github.com/pyodide/pyodide-blog).
+[GitHub](https://github.com/pyodide/pyodide-blog).
 
 Stay tuned.


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide-blog/issues/2

The tone of voice is maybe a but too formal for a blog. [Similar announcement at PyPy](https://morepypy.blogspot.com/2020/08/pypy-is-on-open-collective.html) for instance.

Post preview: https://deploy-preview-6--pyodide-blog.netlify.app//posts/pyodide-joins-open-source-collective/  (the netlify preview uses the wrong subdomain when you click on links)

**Planned publication date:** 2021/11/16