### PR TITLE
Add Google Analytics setup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ buildDrafts: true
 buildFuture: false
 buildExpired: false
 
-# googleAnalytics: UA-123-45
+googleAnalytics: G-DN8KJHC6TN
 
 minify:
     disableXML: true


### PR DESCRIPTION
I'm not a big fan of web tracking, but we still need some kind of measurements to know if anyone will read this blog. Netlify does not provide this information in the free plan. Also the distribution of browser types and browser versions would be good to have before dropping support for some browser versions in Pyodide.

Unless you are aware of better alternatives. For instance, Matomo (formerly Piwik) is open-source, but as far as I can tell they have no free hosted version.