### PR TITLE
Replace Google Analytics with Plausible analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,6 @@ buildDrafts: true
 buildFuture: false
 buildExpired: false
 
-googleAnalytics: G-DN8KJHC6TN
-
 minify:
     disableXML: true
     minifyOutput: true

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,4 +1,3 @@
 {{- if hugo.IsProduction | or (eq .Site.Params.env "production") }}
 <script defer data-domain="blog.pyodide.org" src="https://plausible.io/js/plausible.js"></script>
 {{- end -}}
-

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,4 @@
+{{- if hugo.IsProduction | or (eq .Site.Params.env "production") }}
+<script defer data-domain="blog.pyodide.org" src="https://plausible.io/js/plausible.js"></script>
+{{- end -}}
+


### PR DESCRIPTION
Currently, we are using Google Analytics for viewer stats (which in particular are useful to know the browser versions used). 

Google Analytics is not great privacy-wise and in particular stores a bunch of tracking cookies
![image](https://user-images.githubusercontent.com/630936/185610386-a72769b2-4835-4e15-9a2b-70aaf6c739dd.png)

This means that if we want to be better compliant with various privacy data regulations (including GDPR in Europe), we would at least need to have the cookie popup (which is not helpful). 

Instead, this PR switches to [Plausible analytics](https://plausible.io/) which is lighter, open-source and more privacy focused (in particular doesn't store any cookies). While the platform is open-source, the hosted version is not free, and I'm paying for it as part of my other projects.

Once enabled, aggregated stats would be visible at https://plausible.io/blog.pyodide.org (I made it publicly visible as there is nothing sensitive there)