### PR TITLE
Cross link 0.24 release notes to the changelog

### DIFF
--- a/content/posts/0.24-release.md
+++ b/content/posts/0.24-release.md
@@ -90,6 +90,8 @@ was totally silent and it was hard to tell which versions of which packages were
 being installed from which indices. Now, when run in verbose mode, pip-like
 installation messages are printed to stdout.
 
+For a detailed list of changes, see the [v0.24 changelog](https://pyodide.org/en/0.24.0/project/changelog.html#version-0-24-0).
+
 ## What's next
 
 * Recently clang and Emscripten have added much better support for `externref`.


### PR DESCRIPTION
A minor improvement to make it easier to find the changelog after reading this announcement.