### PR TITLE
Fix reference to `matplotlib-pyodide`'s HTML5 canvas backend

### DIFF
--- a/content/posts/canvas-renderer-matplotlib-in-pyodide/index.md
+++ b/content/posts/canvas-renderer-matplotlib-in-pyodide/index.md
@@ -172,7 +172,7 @@ To use the _\<canvas\>_ backend in your own projects, please use the following s
 
 ```python
 import matplotlib
-matplotlib.use("module://matplotlib.backends.html5_canvas_backend")
+matplotlib.use("module://matplotlib_pyodide.html5_canvas_backend")
 ```
 
 You can find a more complete example of plotting with matplotlib WASM backend [on JSFiddle](https://jsfiddle.net/gh/get/library/pure/pyodide/pyodide-blog/contents/demos/canvas-renderer-matplotlib/demo-1/).

--- a/demos/canvas-renderer-matplotlib/demo-1/demo.js
+++ b/demos/canvas-renderer-matplotlib/demo-1/demo.js
@@ -10,7 +10,7 @@ async function main() {
   pyodide.runPython(`
       import matplotlib
       import numpy as np
-      matplotlib.use("module://matplotlib.backends.html5_canvas_backend")
+      matplotlib.use("module://matplotlib_pyodide.html5_canvas_backend")
       import matplotlib.cm as cm
       from matplotlib import pyplot as plt
       delta = 0.025


### PR DESCRIPTION
Fixes pyodide/matplotlib-pyodide#58