### PR TITLE
Remove Hugo binary from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,37 +6,40 @@ The contents of the Pyodide blog ([blog.pyodide.org](https://blog.pyodide.org))
 
 ## Build locally
 
-To build locally clone this repository, and update submodules
-```
+To build locally, install Hugo, clone this repository, and update the theme submodule:
+
+```bash
 cd pyodide-blog
 git submodule update --init --recursive
 ```
-then build the blog with Hugo,
-```
+then build the blog with Hugo:
+
+```bash
 hugo server -D
 ```
 
-Note: the Linux Hugo executable is included in this repo. If you are on Linux,
-change all `hugo` commands to `./hugo`. Otherwise if you are on a different OS,
-you would need to [install
-Hugo](https://gohugo.io/getting-started/installing/).
+To install Hugo on you platform, please view the [installation instructions](https://gohugo.io/getting-started/installing/)
+for your platform.
 
 ## Contributing
 
 We accept guest posts. If you would like to propose a post,
- - please open an issue with a brief description.
- - Once the general post idea is approved, run,
-   ```
-   hugo new content/posts/<post-url>.md
-   ```
-   and open a PR with the contents of your post in markdown in that file.
+- please open an issue with a brief description.
+- Once the general post idea is approved, run:
+
+  ```bash
+  hugo new content/posts/<post-url>.md
+  ```
+
+  and open a PR with the contents of your post in a Markdown file.
 
 Proposals from existing Pyodide contributors will be given preference.
 
 ## License
 
 The source code for configuration files is distributed under MPL 2.0 license.
-The blog post contents are shared under the [CC
-BY](https://creativecommons.org/licenses/by/4.0/) license. In particular, if
-you republish an adapted version of the content on other websites you must
-credit the original source by linking to it.
+The blog post contents are shared under the [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+license. In particular, if you aim to republish an adapted version of the
+content on other websites, you must credit the original source by linking
+to it, which should comply with their license and our license, and other
+requirements that apply.

--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ params:
           This blog also aims to illustrate how Pyodide can be used for
           real-world projects. If you have a nice Pyodide use case
           that you would like to share, we accept submissions on
-          [Github](https://github.com/pyodide/pyodide-blog).
+          [GitHub](https://github.com/pyodide/pyodide-blog).
 
     socialIcons:
         - name: twitter


### PR DESCRIPTION
I noted that we bundle the Hugo binary in the repository, which becomes a concern for security and a case for repository hygiene. This PR drops it.