### PR TITLE
Add Netlify config, update theme, add social media icons, and restore compatibility with Hugo 0.145.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,10 @@ params:
           [GitHub](https://github.com/pyodide/pyodide-blog).
 
     socialIcons:
+        - name: mastodon
+          url: "https://fosstodon.org/@pyodide"
+        - name: linkedin
+          url: "https://www.linkedin.com/company/pyodide"
         - name: twitter
           url: "https://twitter.com/pyodide"
         - name: github

--- a/config.yaml
+++ b/config.yaml
@@ -110,18 +110,14 @@ params:
         keys: ["title", "permalink", "summary", "content"]
 menu:
     main:
-        - identifier: categories
-          name: categories
-          url: /categories/
-          weight: 10
         - identifier: tags
           name: tags
           url: /tags/
-          weight: 20
+          weight: 10
         - identifier: archives
           name: archives
           url: /archives/
-          weight: 30
+          weight: 20
 # Read: https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#using-hugos-syntax-highlighter-chroma
 # pygmentsUseClasses: true
 markup:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build.environment]
+  HUGO_VERSION = "0.145.0"
+
+[build]
+  base = "/"
+  publish = "public"
+  command = "hugo"


### PR DESCRIPTION
## Description

This PR performs the following cleanups:
- Updates the theme submodule to be compatible with Hugo 0.144.0 (we previously used Hugo 0.88.0 before I removed the binary in #51). I've updated to the tip of the tree as of 08/03/2025 to use the latest enhancements and ensure that we can build with new versions of Hugo, i.e., 0.140.0 and later
	- this also gets us Mastodon and LinkedIn social media icons that were previously missing
- Dropped the "Categories" section from the navbar (it's currently empty on https://blog.pyodide.org/categories/) for now, we can always re-enable it later.
- Added a configuration file for Netlify to pin the Hugo version